### PR TITLE
Use 2021 edition if specified to fmt command

### DIFF
--- a/src/code_execution/playground/util.rs
+++ b/src/code_execution/playground/util.rs
@@ -266,8 +266,7 @@ pub fn apply_local_rustfmt(text: &str, edition: api::Edition) -> Result<api::Pla
             match edition {
                 api::Edition::E2015 => "2015",
                 api::Edition::E2018 => "2018",
-                // Fallback to 2018 edition when 2021 was specified since `rustfmt` does not support it yet
-                api::Edition::E2021 => "2018",
+                api::Edition::E2021 => "2021",
             },
             "--color",
             "never",


### PR DESCRIPTION
No longer fall back to 2018 edition when 2021 edition is specified to the fmt command since it is now supported.
https://github.com/rust-lang/rustfmt/pull/4847